### PR TITLE
Remove useradd

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -131,14 +131,6 @@ then
 fi
 
 #=================================================
-# CREATE DEDICATED USER
-#=================================================
-ynh_script_progression --message="Create a dedicated user" --weight=3
-
-# Create a dedicated system user
-ynh_system_user_create $appname
-
-#=================================================
 # PHP-FPM CONFIGURATION
 #=================================================
 ynh_script_progression --message="Configure php-fpm"
@@ -183,7 +175,7 @@ ynh_replace_string "__APPNAME__" "$appname" "$finalnginxconf"
 
 # Set permissions to app files
 chmod 775 -R $final_path
-chown -R $admin:$appname $final_path
+chown -R $admin $final_path
 
 #=================================================
 # RELOAD NGINX

--- a/scripts/install
+++ b/scripts/install
@@ -142,7 +142,7 @@ cp ../conf/php-fpm.conf "$finalphpconf"
 
 ynh_replace_string "__NAMETOCHANGE__" "$appname" "$finalphpconf"
 ynh_replace_string "__FINALPATH__" "$final_path" "$finalphpconf"
-ynh_replace_string "__USER__" "$appname" "$finalphpconf"
+ynh_replace_string "__USER__" "$admin" "$finalphpconf"
 
 chown root: "$finalphpconf"
 

--- a/scripts/remove
+++ b/scripts/remove
@@ -82,12 +82,6 @@ fi
 #=================================================
 # GENERIC FINALISATION
 #=================================================
-# REMOVE DEDICATED USER
-#=================================================
-ynh_script_progression --message="Remove the dedicated user" --weight=2
-
-# Delete dedicated system user
-ynh_system_user_delete $appname
 
 #=================================================
 # END OF SCRIPT

--- a/scripts/restore
+++ b/scripts/restore
@@ -82,19 +82,11 @@ then
 fi
 
 #=================================================
-# RECREATE THE DEDICATED USER
-#=================================================
-ynh_script_progression --message="Recreate the dedicated user" --weight=2
-
-# Create the dedicated user (if not existing)
-ynh_system_user_create $appname
-
-#=================================================
 # RESTORE USER RIGHTS
 #=================================================
 
 # Restore permissions on app files
-chown -R $admin:$appname $final_path
+chown -R $admin $final_path
 
 #=================================================
 # RESTORE THE PHP-FPM CONFIGURATION


### PR DESCRIPTION
Since the only use of the dedicated user is to own the php-fpm processes, using the app admin for that purpose solves the username length problem.